### PR TITLE
Add local image filenames

### DIFF
--- a/src/scout_archive/items.py
+++ b/src/scout_archive/items.py
@@ -21,6 +21,8 @@ class MeritBadgeItem(scrapy.Item):
     badge_shop_url = scrapy.Field()
     # An image of the badge
     badge_image_url = scrapy.Field()
+    # Local filename of the downloaded badge image
+    badge_image_filename = scrapy.Field()
     # True if the badge is Eagle-required
     is_eagle_required = scrapy.Field()
 
@@ -51,6 +53,8 @@ class CubScoutAdventureItem(scrapy.Item):
     adventure_overview = scrapy.Field()
     # An image of the adventure
     adventure_image_url = scrapy.Field()
+    # Local filename of the downloaded adventure image
+    adventure_image_filename = scrapy.Field()
 
     # Requirements in a structured data format
     requirements_data = scrapy.Field()

--- a/src/scout_archive/pipelines.py
+++ b/src/scout_archive/pipelines.py
@@ -38,14 +38,20 @@ class MeritBadgeFilesPipeline(FilesPipeline):
 class MeritBadgeImagesPipeline(ImagesPipeline):
     def file_path(self, request, response=None, info=None, *, item=None):
         image_guid = sanitize_filename(item["badge_url_slug"]) + "-merit-badge"
-        return f"{image_guid}.jpg"
+        filename = f"{image_guid}.jpg"
+        # Store the local filename in the item
+        item["badge_image_filename"] = filename
+        return filename
 
 
 class CubScoutAdventureImagesPipeline(ImagesPipeline):
     def file_path(self, request, response=None, info=None, *, item=None):
         rank_name = sanitize_filename(item["rank_name"])
         adventure_name = sanitize_filename(item["adventure_name"])
-        return f"{rank_name}/images/{adventure_name}.jpg"
+        filename = f"{rank_name}/images/{adventure_name}.jpg"
+        # Store the local filename in the item
+        item["adventure_image_filename"] = filename
+        return filename
 
 
 class ScoutArchivePipeline:
@@ -90,6 +96,7 @@ class ScoutArchivePipeline:
                 "pdf_url": item.get("badge_pdf_url"),
                 "shop_url": item.get("badge_shop_url"),
                 "image_url": item.get("badge_image_url"),
+                "image_filename": item.get("badge_image_filename"),
                 "requirements": item.get("requirements_data"),
             }
             json.dump(payload, f, ensure_ascii=False, indent=2)
@@ -121,6 +128,7 @@ class ScoutArchivePipeline:
                 "adventure_overview": item.get("adventure_overview"),
                 "url": item.get("adventure_url"),
                 "image_url": item.get("adventure_image_url"),
+                "image_filename": item.get("adventure_image_filename"),
                 "requirements": item.get("requirements_data"),
             }
             json.dump(payload, f, ensure_ascii=False, indent=2)

--- a/src/scout_archive/pipelines.py
+++ b/src/scout_archive/pipelines.py
@@ -144,6 +144,7 @@ class ScoutArchivePipeline:
             "adventure_overview": item.get("adventure_overview"),
             "adventure_url": item.get("adventure_url"),
             "adventure_image_url": item.get("adventure_image_url"),
+            "adventure_image_filename": item.get("adventure_image_filename"),
             "requirements_data": item.get("requirements_data", []),
         }
         markdown_content = template.render(**payload)

--- a/src/scout_archive/pipelines.py
+++ b/src/scout_archive/pipelines.py
@@ -49,8 +49,8 @@ class CubScoutAdventureImagesPipeline(ImagesPipeline):
         rank_name = sanitize_filename(item["rank_name"])
         adventure_name = sanitize_filename(item["adventure_name"])
         filename = f"{rank_name}/images/{adventure_name}.jpg"
-        # Store the local filename in the item
-        item["adventure_image_filename"] = filename
+        # Store just the filename for the template (since MD file is in rank dir)
+        item["adventure_image_filename"] = f"{adventure_name}.jpg"
         return filename
 
 

--- a/src/scout_archive/templates/cub_scout_adventure_template.md
+++ b/src/scout_archive/templates/cub_scout_adventure_template.md
@@ -1,6 +1,6 @@
 # {{ adventure_name }} {{ rank_name }} Adventure
 
-{% if adventure_image_url %}![{{ adventure_name }} {{ rank_name }} adventure belt loop](images/{{ adventure_name|lower|replace(' ', '-') }}.jpg)
+{% if adventure_image_filename %}![{{ adventure_name }} {{ rank_name }} adventure belt loop]({{ adventure_image_filename }})
 {% endif %}
 
 - **Adventure name:** {{ adventure_name }}

--- a/src/scout_archive/templates/cub_scout_adventure_template.md
+++ b/src/scout_archive/templates/cub_scout_adventure_template.md
@@ -1,6 +1,6 @@
 # {{ adventure_name }} {{ rank_name }} Adventure
 
-{% if adventure_image_filename %}![{{ adventure_name }} {{ rank_name }} adventure belt loop]({{ adventure_image_filename }})
+{% if adventure_image_filename %}![{{ adventure_name }} {{ rank_name }} adventure belt loop](images/{{ adventure_image_filename }})
 {% endif %}
 
 - **Adventure name:** {{ adventure_name }}

--- a/src/scout_archive/templates/merit_badge_template.md
+++ b/src/scout_archive/templates/merit_badge_template.md
@@ -18,8 +18,8 @@
 
 # {{ badge_name }} Merit Badge
 
-{% if images and images|length > 0 %}
-![{{ badge_name }} Merit Badge](images/{{ images[0].path }})
+{% if badge_image_filename %}
+![{{ badge_name }} Merit Badge](images/{{ badge_image_filename }})
 {% endif %}
 
 ## Overview


### PR DESCRIPTION
Improves the handling and referencing of image filenames for both merit badges and Cub Scout adventures. Instead of relying on derived or pipeline-specific filenames, the local image filename is now explicitly stored in each item and used directly in templates and output files. This makes image references more robust and simplifies template logic.

