### PR TITLE
Fix merit badge requirement list nesting

### DIFF
--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -108,6 +108,8 @@ HTML
   - Cleans attributes to a controlled HTML subset.
   - Normalizes whitespace and inline spacing.
   - Repairs flattened option/list sequences without badge-specific rules.
+  - Assigns a contiguous numbered list to the immediately preceding alphabetic
+    action or named option when its text explicitly introduces that list.
   - Adds downstream metadata such as `text`, `requirement_path`, `node_kind`,
     `is_container`, and `requires_response`.
 

--- a/docs/json-format.md
+++ b/docs/json-format.md
@@ -58,6 +58,11 @@ Notes:
 
 - Use `label` for numbering in UIs; `id` is internal/unstable.
 - The `requirements` array is hierarchical; each node owns its children.
+- When an alphabetic action requirement or named option clearly introduces a
+  contiguous numbered list, those numbered entries are children of that action.
+  Their `requirement_path` values include the governing action path (for example,
+  `"1.b.1"` rather than `"1.1"`). Source content, resources, and `id` values are
+  unchanged by this semantic hierarchy repair.
 
 Example (truncated):
 

--- a/docs/json-format.md
+++ b/docs/json-format.md
@@ -40,6 +40,9 @@ Requirement object (semantic tree):
 - `is_container` (boolean): True when the node owns child requirements.
 - `requires_response` (boolean): True when the node is an answerable/action
   requirement; false for pure instruction and option containers.
+- `scoped_clauses` (array): Exact substrings of `text` whose action scope can
+  be inferred from the semantic tree (see below). This list is not intended to
+  be an exhaustive grammatical decomposition.
 - `content` (array): Requirement content as a semantic HTML node list.
 - `resources` (array): Resource links (see below).
 - `sub_requirements` (array): Child requirements.
@@ -54,10 +57,30 @@ Resource object:
 - `title` (string)
 - `url` (string)
 
+Scoped clause object:
+
+- `text` (string): An exact substring of the owning requirement's normalized
+  `text`.
+- `scope` (string): One of `"requirement"`, `"children"`, or `"ambiguous"`.
+  A requirement-scoped clause is performed once at the owning node and must
+  not be inherited by its children. A children-scoped clause governs each
+  direct child and is the parent context downstream consumers should inherit.
+  An ambiguous clause combines or follows actions whose ownership cannot be
+  separated conservatively; consumers must not assume that it applies to every
+  child.
+
 Notes:
 
 - Use `label` for numbering in UIs; `id` is internal/unstable.
 - The `requirements` array is hierarchical; each node owns its children.
+- `requires_response` remains a coarse, node-level compatibility signal, while
+  `scoped_clauses` is authoritative when deciding which portions of a
+  container's text to inherit. On a mixed container, a `requirement` clause
+  keeps `requires_response` true even when another clause only introduces
+  children.
+  An empty `scoped_clauses` list means no clause scope was inferred or the node
+  has no children; consumers of older archives should fall back to their
+  existing node-level behavior.
 - When an alphabetic action requirement or named option clearly introduces a
   contiguous numbered list, those numbered entries are children of that action.
   Their `requirement_path` values include the governing action path (for example,
@@ -83,13 +106,16 @@ Example (truncated):
     {
       "id": "123",
       "label": "1",
-      "text": "Discuss...",
+      "text": "Discuss the following:",
       "requirement_path": "1",
       "node_kind": "instruction_container",
       "is_container": true,
       "requires_response": false,
+      "scoped_clauses": [
+        { "text": "Discuss the following:", "scope": "children" }
+      ],
       "content": [
-        { "type": "text", "value": "Discuss..." }
+        { "type": "text", "value": "Discuss the following:" }
       ],
       "resources": [],
       "sub_requirements": [
@@ -101,6 +127,7 @@ Example (truncated):
           "node_kind": "action_requirement",
           "is_container": false,
           "requires_response": true,
+          "scoped_clauses": [],
           "content": [
             { "type": "text", "value": "Explain..." }
           ],
@@ -139,6 +166,8 @@ Requirement object:
 - `is_container` (boolean): True when the node owns child requirements.
 - `requires_response` (boolean): True when the node is an answerable/action
   requirement; false for pure instruction and option containers.
+- `scoped_clauses` (array): Exact text clauses with the same scope contract as
+  merit badge requirements above.
 - `content` (array): Requirement content as a semantic HTML node list.
 - `resources` (array): Resource links.
 - `sub_requirements` (array): Child requirements.
@@ -175,6 +204,7 @@ Example (truncated):
       "node_kind": "action_requirement",
       "is_container": false,
       "requires_response": true,
+      "scoped_clauses": [],
       "content": [
         { "type": "text", "value": "Show you are prepared..." }
       ],

--- a/src/scout_archive/requirements_pipeline.py
+++ b/src/scout_archive/requirements_pipeline.py
@@ -34,6 +34,11 @@ class Resource(BaseModel):
     url: str
 
 
+class ScopedClause(BaseModel):
+    text: str
+    scope: Literal["requirement", "children", "ambiguous"]
+
+
 class SemanticRequirement(BaseModel):
     id: str
     label: Optional[str] = None
@@ -44,6 +49,7 @@ class SemanticRequirement(BaseModel):
     ] = "action_requirement"
     is_container: bool = False
     requires_response: bool = True
+    scoped_clauses: List[ScopedClause] = Field(default_factory=list)
     content: List[RawNode] = Field(default_factory=list)
     resources: List[Resource] = Field(default_factory=list)
     sub_requirements: List["SemanticRequirement"] = Field(default_factory=list)
@@ -191,6 +197,27 @@ class SemanticProcessor:
         r"\bthe official merit badge pamphlets are now free and downloadable\b",
         re.IGNORECASE,
     )
+    ACTION_VERBS = (
+        "arrange|ask|build|choose|collect|compare|complete|conduct|consider|contact|"
+        "create|define|demonstrate|describe|design|determine|discuss|do|draw|"
+        "explain|find|format|give|identify|interview|investigate|keep|learn|list|"
+        "make|name|observe|plan|prepare|produce|record|research|select|share|show|"
+        "tell|think|use|visit|write"
+    )
+    ACTION_CLAUSE_RE = re.compile(
+        rf"^\s*(?:\([^)]*\)\s*)?(?:"
+        rf"(?:{ACTION_VERBS})\b|"
+        rf"(?:after|as|before|during|for|in|once|upon|using|when|while|with)\b"
+        rf"[^.!?]*,\s*(?:{ACTION_VERBS})\b)",
+        re.IGNORECASE,
+    )
+    MIXED_CHOICE_CLAUSE_RE = re.compile(
+        rf"^\s*\S.+\b(?:and|then)\s+(?:do|choose|complete|select)\b[^.!?]*"
+        rf"\bthe following\b|\bthe following\b[^.!?]*\band\s+"
+        rf"(?:{ACTION_VERBS})\b",
+        re.IGNORECASE,
+    )
+    HEADING_CONNECTORS = {"a", "an", "and", "for", "in", "of", "or", "the", "to"}
 
     def process(self, raw_items: List[RawRequirementItem]) -> List[SemanticRequirement]:
         processed: List[SemanticRequirement] = []
@@ -1035,12 +1062,80 @@ class SemanticProcessor:
             )
             requirement.is_container = bool(requirement.sub_requirements)
             requirement.node_kind = self._classify_requirement(requirement)
-            requirement.requires_response = (
-                requirement.node_kind == "action_requirement"
-            )
+            requirement.scoped_clauses = self._infer_scoped_clauses(requirement)
+            self._apply_scoped_clause_semantics(requirement)
             self._annotate_requirements(
                 requirement.sub_requirements, requirement.requirement_path
             )
+
+    def _infer_scoped_clauses(
+        self, requirement: SemanticRequirement
+    ) -> List[ScopedClause]:
+        """Infer only clauses whose ownership is clear from a child-list introducer."""
+        if not requirement.sub_requirements or not requirement.text:
+            return []
+
+        clauses = self._sentence_clauses(requirement.text)
+        governing_indexes = [
+            index
+            for index, clause in enumerate(clauses)
+            if introduces_numbered_list(clause)
+        ]
+        if len(governing_indexes) != 1:
+            return [
+                ScopedClause(text=clause, scope="ambiguous")
+                for index, clause in enumerate(clauses)
+                if index in governing_indexes or self._is_action_clause(clause)
+            ]
+
+        governing_index = governing_indexes[0]
+        governing_clause = clauses[governing_index]
+        if self.MIXED_CHOICE_CLAUSE_RE.search(governing_clause):
+            governing_scope: Literal["children", "ambiguous"] = "ambiguous"
+        else:
+            governing_scope = "children"
+
+        scoped: List[ScopedClause] = []
+        for index, clause in enumerate(clauses):
+            if index < governing_index and self._is_action_clause(clause):
+                scoped.append(ScopedClause(text=clause, scope="requirement"))
+            elif index == governing_index:
+                scoped.append(ScopedClause(text=clause, scope=governing_scope))
+            elif self._is_action_clause(clause):
+                # A later action might apply once after the list or to every child.
+                scoped.append(ScopedClause(text=clause, scope="ambiguous"))
+        return scoped
+
+    def _sentence_clauses(self, text: str) -> List[str]:
+        return [
+            clause.strip()
+            for clause in re.split(r"(?<=[.!?])\s+(?=[A-Z(])", text)
+            if clause.strip()
+        ]
+
+    def _is_action_clause(self, clause: str) -> bool:
+        if self._is_likely_heading_clause(clause):
+            return False
+        return bool(self.ACTION_CLAUSE_RE.search(clause))
+
+    def _is_likely_heading_clause(self, clause: str) -> bool:
+        words = re.findall(r"[A-Za-z]+", clause)
+        if not words or len(words) > 5:
+            return False
+        return all(
+            word.lower() in self.HEADING_CONNECTORS or word[0].isupper()
+            for word in words
+        )
+
+    def _apply_scoped_clause_semantics(self, requirement: SemanticRequirement) -> None:
+        requirement.requires_response = requirement.node_kind == "action_requirement"
+        # Clause scope refines the existing node classification. A clear action
+        # owned by the requirement must not be suppressed merely because the
+        # same node also introduces children.
+        if any(clause.scope == "requirement" for clause in requirement.scoped_clauses):
+            if requirement.node_kind == "instruction_container":
+                requirement.node_kind = "action_requirement"
+            requirement.requires_response = True
 
     def _requirement_path_segment(
         self, requirement: SemanticRequirement, index: int

--- a/src/scout_archive/requirements_pipeline.py
+++ b/src/scout_archive/requirements_pipeline.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Annotated, Callable, Dict, List, Literal, Optional, Union
 
 from bs4 import BeautifulSoup, NavigableString, Tag
-from pydantic import BaseModel, Field, TypeAdapter
+from pydantic import BaseModel, Field, PrivateAttr, TypeAdapter
 
 
 class RawTextNode(BaseModel):
@@ -47,6 +47,9 @@ class SemanticRequirement(BaseModel):
     content: List[RawNode] = Field(default_factory=list)
     resources: List[Resource] = Field(default_factory=list)
     sub_requirements: List["SemanticRequirement"] = Field(default_factory=list)
+    # Reparenting changes the tree shape but must not turn its action owner into
+    # a shape-classified instruction container. Private state is not archived.
+    _owns_repaired_numbered_list: bool = PrivateAttr(default=False)
 
 
 RawElementNode.model_rebuild()
@@ -56,6 +59,20 @@ SemanticRequirement.model_rebuild()
 
 def _normalize_url(url: str) -> str:
     return re.sub(r"(?i)(?:%20)+$", "", url.strip()).rstrip("?#")
+
+
+def introduces_numbered_list(text: str) -> bool:
+    """Return whether requirement text clearly introduces a following list."""
+    normalized = re.sub(r"\s+", " ", text).strip()
+    if not normalized:
+        return False
+    return bool(
+        re.search(r"\bthe following\b", normalized, re.IGNORECASE)
+        or re.search(r"\blist below\b", normalized, re.IGNORECASE)
+        or re.search(r"\bincluding\s*:", normalized, re.IGNORECASE)
+        or re.search(r"\bas follows\b", normalized, re.IGNORECASE)
+        or normalized.endswith(":")
+    )
 
 
 class HtmlExtractor:
@@ -684,7 +701,8 @@ class SemanticProcessor:
     def _repair_requirement_hierarchy(
         self, requirements: List[SemanticRequirement]
     ) -> List[SemanticRequirement]:
-        grouped = self._group_option_containers(requirements)
+        governed = self._nest_governed_numbered_lists(requirements)
+        grouped = self._group_option_containers(governed)
         nested = self._nest_labeled_descendants(grouped)
         repaired: List[SemanticRequirement] = []
         for requirement in nested:
@@ -695,6 +713,48 @@ class SemanticProcessor:
             repaired.append(requirement)
             repaired.extend(promoted_siblings)
         return repaired
+
+    def _nest_governed_numbered_lists(
+        self, requirements: List[SemanticRequirement]
+    ) -> List[SemanticRequirement]:
+        nested: List[SemanticRequirement] = []
+        index = 0
+        while index < len(requirements):
+            requirement = requirements[index]
+            run_end = self._contiguous_numbered_run_end(requirements, index + 1)
+            if (
+                run_end is not None
+                and self._can_govern_numbered_list(requirement)
+                and self._is_list_intro_requirement(requirement)
+            ):
+                requirement.sub_requirements.extend(requirements[index + 1 : run_end])
+                requirement._owns_repaired_numbered_list = True
+                nested.append(requirement)
+                index = run_end
+                continue
+            nested.append(requirement)
+            index += 1
+        return nested
+
+    def _contiguous_numbered_run_end(
+        self, requirements: List[SemanticRequirement], start: int
+    ) -> Optional[int]:
+        if start >= len(requirements) or requirements[start].label != "1":
+            return None
+        expected = 1
+        index = start
+        while index < len(requirements):
+            if requirements[index].label != str(expected):
+                break
+            expected += 1
+            index += 1
+        return index if expected > 2 else None
+
+    def _can_govern_numbered_list(self, requirement: SemanticRequirement) -> bool:
+        if self._label_kind(requirement.label) == "lower-alpha":
+            return True
+        text = self._clean_plain_text(self._plain_text(requirement.content))
+        return bool(self.OPTION_PREFIX_RE.match(text))
 
     def _group_option_containers(
         self, requirements: List[SemanticRequirement]
@@ -730,14 +790,6 @@ class SemanticProcessor:
 
         for requirement in requirements:
             label_kind = self._label_kind(requirement.label)
-            if (
-                label_kind == "numeric"
-                and current_alpha is not None
-                and self._is_list_intro_requirement(current_alpha)
-            ):
-                current_alpha.sub_requirements.append(requirement)
-                current_numeric = requirement
-                continue
             if (
                 label_kind == "lower-alpha"
                 and current_numeric is not None
@@ -777,9 +829,7 @@ class SemanticProcessor:
 
     def _is_list_intro_requirement(self, requirement: SemanticRequirement) -> bool:
         text = self._clean_plain_text(self._plain_text(requirement.content))
-        if text.endswith(":") and re.search(r"\bfollowing\b", text, re.I):
-            return True
-        return bool(re.search(r"\bthe following(?:\s+options?)?:?$", text, re.I))
+        return introduces_numbered_list(text)
 
     def _starts_flat_option_group(
         self,
@@ -1015,10 +1065,19 @@ class SemanticProcessor:
         text = self._clean_plain_text(self._plain_text(requirement.content))
         if not self.OPTION_PREFIX_RE.match(text):
             return False
-        if requirement.sub_requirements:
+        if requirement.sub_requirements and self._is_option_heading_requirement(
+            requirement
+        ):
             return True
         return bool(
-            re.search(r"\bdo\s+(?:all|one|two|three)?\s*of the following\b", text, re.I)
+            re.search(
+                r"\b(?:do|complete|choose|show|discuss|explain|identify|list|tell|"
+                r"make|draw|select)\s+"
+                r"(?:all|one|two|three|four|five|six|seven|eight|nine|ten|"
+                r"\d+)?\s*(?:of\s+)?the following\b",
+                text,
+                re.IGNORECASE,
+            )
             or re.search(r"\bfollowing\s+options?:\s*$", text, re.I)
         )
 
@@ -1028,6 +1087,10 @@ class SemanticProcessor:
         text = self._clean_plain_text(self._plain_text(requirement.content))
         if not text:
             return True
+        if requirement._owns_repaired_numbered_list:
+            return self._is_section_heading_requirement(
+                requirement
+            ) or self._is_standalone_list_instruction(text)
         if self._is_section_heading_requirement(requirement):
             return True
         lower_text = text.lower()
@@ -1042,6 +1105,9 @@ class SemanticProcessor:
             re.IGNORECASE,
         ):
             return True
+        return self._is_standalone_list_instruction(text)
+
+    def _is_standalone_list_instruction(self, text: str) -> bool:
         return bool(
             re.fullmatch(
                 r"(?:[A-Z][A-Za-z0-9 ,&/'-]{1,80}\.\s*)?"

--- a/src/scripts/validate-cub-adventures-archive.py
+++ b/src/scripts/validate-cub-adventures-archive.py
@@ -10,6 +10,7 @@ import glob
 import sys
 import re
 from urllib.parse import urlparse
+from typing import Any
 
 # Import settings from Scrapy project
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -33,6 +34,7 @@ ALLOWED_NODE_KINDS = {
     "instruction_container",
     "option_container",
 }
+ALLOWED_CLAUSE_SCOPES = {"requirement", "children", "ambiguous"}
 
 
 def _node_text(nodes):
@@ -76,6 +78,41 @@ def _validate_nodes(nodes, path, errors, warnings):
         errors.append(f"{path} content[{idx}] has invalid type '{node_type}'")
 
 
+def _validate_scoped_clauses(
+    req: dict[str, Any], path: str, errors: list[str], warnings: list[str]
+) -> None:
+    clauses = req.get("scoped_clauses")
+    if clauses is None:
+        # Older archive releases predate clause scoping and remain valid input.
+        return
+    if not isinstance(clauses, list):
+        errors.append(f"{path} scoped_clauses is not a list")
+        return
+
+    requirement_text = req.get("text")
+    for idx, clause in enumerate(clauses):
+        clause_path = f"{path}.scoped_clauses[{idx}]"
+        if not isinstance(clause, dict):
+            errors.append(f"{clause_path} is not an object")
+            continue
+        clause_text = clause.get("text")
+        scope = clause.get("scope")
+        if not isinstance(clause_text, str) or not clause_text:
+            errors.append(f"{clause_path} missing text")
+        elif isinstance(requirement_text, str) and clause_text not in requirement_text:
+            errors.append(f"{clause_path} text is not part of requirement text")
+        if scope not in ALLOWED_CLAUSE_SCOPES:
+            errors.append(f"{clause_path} invalid scope '{scope}'")
+        elif scope == "ambiguous":
+            warnings.append(f"{clause_path} has ambiguous action scope")
+
+    if any(
+        isinstance(clause, dict) and clause.get("scope") == "requirement"
+        for clause in clauses
+    ) and not req.get("requires_response"):
+        errors.append(f"{path} suppresses a requirement-scoped action")
+
+
 def _validate_requirement_tree(requirements, path, errors, warnings, require_text):
     if not isinstance(requirements, list):
         errors.append(f"{path} is not a list")
@@ -115,6 +152,8 @@ def _validate_requirement_tree(requirements, path, errors, warnings, require_tex
 
         if not isinstance(req.get("requires_response"), bool):
             errors.append(f"{req_path} requires_response is not a boolean")
+
+        _validate_scoped_clauses(req, req_path, errors, warnings)
 
         content = req.get("content")
         if content is None:

--- a/src/scripts/validate-merit-badges-archive.py
+++ b/src/scripts/validate-merit-badges-archive.py
@@ -9,6 +9,7 @@ import json
 import glob
 import re
 import sys
+from typing import Any
 
 # Import settings from Scrapy project
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -44,6 +45,7 @@ ALLOWED_NODE_KINDS = {
     "instruction_container",
     "option_container",
 }
+ALLOWED_CLAUSE_SCOPES = {"requirement", "children", "ambiguous"}
 
 
 def _node_text(nodes):
@@ -87,6 +89,41 @@ def _validate_nodes(nodes, path, errors, warnings):
         errors.append(f"{path} content[{idx}] has invalid type '{node_type}'")
 
 
+def _validate_scoped_clauses(
+    req: dict[str, Any], path: str, errors: list[str], warnings: list[str]
+) -> None:
+    clauses = req.get("scoped_clauses")
+    if clauses is None:
+        # Older archive releases predate clause scoping and remain valid input.
+        return
+    if not isinstance(clauses, list):
+        errors.append(f"{path} scoped_clauses is not a list")
+        return
+
+    requirement_text = req.get("text")
+    for idx, clause in enumerate(clauses):
+        clause_path = f"{path}.scoped_clauses[{idx}]"
+        if not isinstance(clause, dict):
+            errors.append(f"{clause_path} is not an object")
+            continue
+        clause_text = clause.get("text")
+        scope = clause.get("scope")
+        if not isinstance(clause_text, str) or not clause_text:
+            errors.append(f"{clause_path} missing text")
+        elif isinstance(requirement_text, str) and clause_text not in requirement_text:
+            errors.append(f"{clause_path} text is not part of requirement text")
+        if scope not in ALLOWED_CLAUSE_SCOPES:
+            errors.append(f"{clause_path} invalid scope '{scope}'")
+        elif scope == "ambiguous":
+            warnings.append(f"{clause_path} has ambiguous action scope")
+
+    if any(
+        isinstance(clause, dict) and clause.get("scope") == "requirement"
+        for clause in clauses
+    ) and not req.get("requires_response"):
+        errors.append(f"{path} suppresses a requirement-scoped action")
+
+
 def _validate_requirement_tree(requirements, path, errors, warnings):
     if not isinstance(requirements, list):
         errors.append(f"{path} is not a list")
@@ -127,6 +164,8 @@ def _validate_requirement_tree(requirements, path, errors, warnings):
 
         if not isinstance(req.get("requires_response"), bool):
             errors.append(f"{req_path} requires_response is not a boolean")
+
+        _validate_scoped_clauses(req, req_path, errors, warnings)
 
         content = req.get("content")
         if content is None:

--- a/src/scripts/validate-merit-badges-archive.py
+++ b/src/scripts/validate-merit-badges-archive.py
@@ -7,6 +7,7 @@ This helps detect if the source website has changed in a way that breaks our arc
 import os
 import json
 import glob
+import re
 import sys
 
 # Import settings from Scrapy project
@@ -17,6 +18,7 @@ from scout_archive.settings import (
     MIN_BADGE_FILE_SIZE_BYTES,
     MAX_BADGE_EMPTY_FIELDS,
 )
+from scout_archive.requirements_pipeline import introduces_numbered_list
 
 # Known Eagle-required badges that should always be present
 EAGLE_REQUIRED_BADGES = [
@@ -89,6 +91,7 @@ def _validate_requirement_tree(requirements, path, errors, warnings):
     if not isinstance(requirements, list):
         errors.append(f"{path} is not a list")
         return
+    _validate_governed_numbered_siblings(requirements, path, warnings)
     for idx, req in enumerate(requirements):
         req_path = f"{path}[{idx}]"
         if not isinstance(req, dict):
@@ -154,6 +157,36 @@ def _validate_requirement_tree(requirements, path, errors, warnings):
         else:
             _validate_requirement_tree(
                 sub_requirements, f"{req_path}.sub_requirements", errors, warnings
+            )
+
+
+def _validate_governed_numbered_siblings(requirements, path, warnings):
+    for idx, req in enumerate(requirements[:-1]):
+        if not isinstance(req, dict):
+            continue
+        label = req.get("label")
+        text = req.get("text")
+        is_alpha_action = isinstance(label, str) and re.fullmatch(r"[a-z]", label)
+        is_option_action = isinstance(text, str) and re.match(
+            r"^\s*Option\s+[A-Za-z0-9]+\b", text, re.IGNORECASE
+        )
+        if not (is_alpha_action or is_option_action):
+            continue
+        if not isinstance(text, str) or not introduces_numbered_list(text):
+            continue
+        if idx + 2 >= len(requirements):
+            continue
+        next_req = requirements[idx + 1]
+        second_req = requirements[idx + 2]
+        if (
+            isinstance(next_req, dict)
+            and next_req.get("label") == "1"
+            and isinstance(second_req, dict)
+            and second_req.get("label") == "2"
+        ):
+            warnings.append(
+                f"{path}[{idx}] likely governs numbered siblings beginning at "
+                f"{path}[{idx + 1}]"
             )
 
 

--- a/tests/test_requirements_pipeline.py
+++ b/tests/test_requirements_pipeline.py
@@ -288,6 +288,163 @@ class SemanticProcessorTest(unittest.TestCase):
         )
         self.assertEqual(requirements[0].sub_requirements[0].sub_requirements, [])
 
+    def test_scopes_health_care_parent_actions_separately_from_child_action(
+        self,
+    ) -> None:
+        parent = RawRequirementItem(
+            id="5",
+            content_nodes=self.extractor.extract_nodes(
+                "5. Select one career from any of the lists in requirements 1, 2, "
+                "3, or 4 and arrange to visit that professional at their workplace. "
+                "Discuss with your counselor the following:"
+            ),
+            sub_requirements=[
+                RawRequirementItem(
+                    id="a",
+                    content_nodes=self.extractor.extract_nodes(
+                        "(a) Why did they choose their particular career?"
+                    ),
+                )
+            ],
+        )
+
+        requirement = self.processor.process([parent])[0]
+
+        self.assertEqual(
+            [clause.model_dump() for clause in requirement.scoped_clauses],
+            [
+                {
+                    "text": (
+                        "Select one career from any of the lists in requirements 1, "
+                        "2, 3, or 4 and arrange to visit that professional at their "
+                        "workplace."
+                    ),
+                    "scope": "requirement",
+                },
+                {
+                    "text": "Discuss with your counselor the following:",
+                    "scope": "children",
+                },
+            ],
+        )
+        self.assertEqual(requirement.node_kind, "action_requirement")
+        self.assertTrue(requirement.requires_response)
+
+    def test_preserves_disabilities_advocacy_explanation_as_parent_action(
+        self,
+    ) -> None:
+        parent = RawRequirementItem(
+            id="5",
+            content_nodes=self.extractor.extract_nodes(
+                "5. Explain what advocacy is. Do ONE of the following:"
+            ),
+            sub_requirements=[
+                RawRequirementItem(
+                    id="a",
+                    content_nodes=self.extractor.extract_nodes(
+                        "(a) Present a disabilities awareness program."
+                    ),
+                )
+            ],
+        )
+
+        requirement = self.processor.process([parent])[0]
+
+        self.assertEqual(
+            [clause.model_dump() for clause in requirement.scoped_clauses],
+            [
+                {"text": "Explain what advocacy is.", "scope": "requirement"},
+                {"text": "Do ONE of the following:", "scope": "children"},
+            ],
+        )
+        self.assertEqual(requirement.node_kind, "action_requirement")
+        self.assertTrue(requirement.requires_response)
+
+    def test_scopes_all_first_aid_wound_actions_to_children(self) -> None:
+        parent = RawRequirementItem(
+            id="3",
+            content_nodes=self.extractor.extract_nodes(
+                "3. Wounds with No External Bleeding. Describe the symptoms and "
+                "signs of, show first aid for, and explain prevention of these wounds:"
+            ),
+            sub_requirements=[
+                RawRequirementItem(
+                    id="a",
+                    content_nodes=self.extractor.extract_nodes(
+                        "(a) Closed wounds, such as a bruise or a hematoma"
+                    ),
+                )
+            ],
+        )
+
+        requirement = self.processor.process([parent])[0]
+
+        self.assertEqual(
+            [clause.model_dump() for clause in requirement.scoped_clauses],
+            [
+                {
+                    "text": (
+                        "Describe the symptoms and signs of, show first aid for, and "
+                        "explain prevention of these wounds:"
+                    ),
+                    "scope": "children",
+                }
+            ],
+        )
+        self.assertEqual(requirement.node_kind, "action_requirement")
+        self.assertTrue(requirement.requires_response)
+
+    def test_marks_inseparable_parent_and_child_actions_as_ambiguous(self) -> None:
+        parent = RawRequirementItem(
+            id="1",
+            content_nodes=self.extractor.extract_nodes(
+                "1. Explain the safety rule and do ONE of the following:"
+            ),
+            sub_requirements=[
+                RawRequirementItem(
+                    id="a",
+                    content_nodes=self.extractor.extract_nodes("(a) Make a poster."),
+                )
+            ],
+        )
+
+        requirement = self.processor.process([parent])[0]
+
+        self.assertEqual(
+            [clause.model_dump() for clause in requirement.scoped_clauses],
+            [
+                {
+                    "text": "Explain the safety rule and do ONE of the following:",
+                    "scope": "ambiguous",
+                }
+            ],
+        )
+        self.assertEqual(requirement.node_kind, "action_requirement")
+        self.assertTrue(requirement.requires_response)
+
+    def test_does_not_treat_action_word_heading_as_parent_action(self) -> None:
+        parent = RawRequirementItem(
+            id="7",
+            content_nodes=self.extractor.extract_nodes(
+                "7. Complete the Program. Do the following:"
+            ),
+            sub_requirements=[
+                RawRequirementItem(
+                    id="a",
+                    content_nodes=self.extractor.extract_nodes("(a) Record your plan."),
+                )
+            ],
+        )
+
+        requirement = self.processor.process([parent])[0]
+
+        self.assertEqual(
+            [clause.model_dump() for clause in requirement.scoped_clauses],
+            [{"text": "Do the following:", "scope": "children"}],
+        )
+        self.assertEqual(requirement.node_kind, "instruction_container")
+        self.assertFalse(requirement.requires_response)
+
     def test_option_prefixed_action_requirements_stay_answerable(self) -> None:
         html = """
         <div class="mb-requirement-container">

--- a/tests/test_requirements_pipeline.py
+++ b/tests/test_requirements_pipeline.py
@@ -86,6 +86,8 @@ class SemanticProcessorTest(unittest.TestCase):
 
         child_b = requirements[0].sub_requirements[1]
         self.assertEqual(child_b.requirement_path, "5.b")
+        self.assertEqual(child_b.node_kind, "instruction_container")
+        self.assertEqual(child_b.requires_response, False)
         self.assertEqual(
             [child.requirement_path for child in child_b.sub_requirements],
             ["5.b.1", "5.b.2"],
@@ -123,6 +125,168 @@ class SemanticProcessorTest(unittest.TestCase):
         )
         self.assertEqual(child_b.sub_requirements[1].node_kind, "action_requirement")
         self.assertEqual(child_b.sub_requirements[1].requires_response, True)
+
+    def test_nests_numbered_lists_for_explicit_introduction_patterns(self) -> None:
+        introduction_texts = [
+            "Choose two situations from the list below. Discuss your choices.",
+            "Explain injuries searchers could develop, including: Discuss prevention.",
+            "Identify the following: Then compare your findings.",
+            "Set up the demonstration as follows, then explain the result.",
+        ]
+
+        for text in introduction_texts:
+            with self.subTest(text=text):
+                parent = RawRequirementItem(
+                    id="1",
+                    content_nodes=self.extractor.extract_nodes("1. Do the following:"),
+                    sub_requirements=[
+                        RawRequirementItem(
+                            id="alpha-id",
+                            content_nodes=self.extractor.extract_nodes(f"(a) {text}"),
+                        ),
+                        RawRequirementItem(
+                            id="numeric-one",
+                            content_nodes=self.extractor.extract_nodes(
+                                "1. First topic.<br><i>Resources:</i>"
+                                '<a href="https://example.com/topic-one">Topic one</a>'
+                            ),
+                        ),
+                        RawRequirementItem(
+                            id="numeric-two",
+                            content_nodes=self.extractor.extract_nodes(
+                                "2. Second topic."
+                            ),
+                        ),
+                    ],
+                )
+
+                requirements = self.processor.process([parent])
+                child_a = requirements[0].sub_requirements[0]
+
+                self.assertEqual(
+                    [child.requirement_path for child in child_a.sub_requirements],
+                    ["1.a.1", "1.a.2"],
+                )
+                self.assertEqual(
+                    [child.id for child in child_a.sub_requirements],
+                    ["numeric-one", "numeric-two"],
+                )
+                self.assertEqual(child_a.node_kind, "action_requirement")
+                self.assertEqual(child_a.requires_response, True)
+                self.assertEqual(child_a.sub_requirements[0].text, "First topic.")
+                self.assertEqual(
+                    child_a.sub_requirements[0].resources[0].url,
+                    "https://example.com/topic-one",
+                )
+
+    def test_nests_numbered_list_under_named_option_action(self) -> None:
+        parent = RawRequirementItem(
+            id="4",
+            content_nodes=self.extractor.extract_nodes("4. Do ONE option:"),
+            sub_requirements=[
+                RawRequirementItem(
+                    id="option-a",
+                    content_nodes=self.extractor.extract_nodes(
+                        "Option A—Access. Visit TWO of the following locations."
+                    ),
+                ),
+                RawRequirementItem(
+                    id="location-one",
+                    content_nodes=self.extractor.extract_nodes("1. Your school."),
+                ),
+                RawRequirementItem(
+                    id="location-two",
+                    content_nodes=self.extractor.extract_nodes("2. A public park."),
+                ),
+                RawRequirementItem(
+                    id="c",
+                    content_nodes=self.extractor.extract_nodes(
+                        "(c) Discuss what you learned."
+                    ),
+                ),
+            ],
+        )
+
+        requirements = self.processor.process([parent])
+        option_a = requirements[0].sub_requirements[0]
+
+        self.assertEqual(
+            [child.requirement_path for child in requirements[0].sub_requirements],
+            ["4.option-a", "4.c"],
+        )
+        self.assertEqual(option_a.requirement_path, "4.option-a")
+        self.assertEqual(option_a.node_kind, "action_requirement")
+        self.assertEqual(option_a.requires_response, True)
+        self.assertEqual(
+            [child.requirement_path for child in option_a.sub_requirements],
+            ["4.option-a.1", "4.option-a.2"],
+        )
+
+    def test_keeps_option_prefixed_list_instruction_as_container(self) -> None:
+        parent = RawRequirementItem(
+            id="6",
+            content_nodes=self.extractor.extract_nodes("6. Do ONE option:"),
+            sub_requirements=[
+                RawRequirementItem(
+                    id="option-a",
+                    content_nodes=self.extractor.extract_nodes(
+                        "<strong>Option A: Unsolved Mysteries of Physics.</strong> "
+                        "Discuss the following with your counselor:"
+                    ),
+                    sub_requirements=[
+                        RawRequirementItem(
+                            id="1",
+                            content_nodes=self.extractor.extract_nodes(
+                                "1. Explain dark matter."
+                            ),
+                        ),
+                        RawRequirementItem(
+                            id="2",
+                            content_nodes=self.extractor.extract_nodes(
+                                "2. Explain dark energy."
+                            ),
+                        ),
+                    ],
+                )
+            ],
+        )
+
+        requirements = self.processor.process([parent])
+        option_a = requirements[0].sub_requirements[0]
+
+        self.assertEqual(option_a.requirement_path, "6.option-a")
+        self.assertEqual(option_a.node_kind, "option_container")
+        self.assertEqual(option_a.requires_response, False)
+
+    def test_keeps_ungoverned_numbered_siblings_flat(self) -> None:
+        parent = RawRequirementItem(
+            id="1",
+            content_nodes=self.extractor.extract_nodes("1. Do the following:"),
+            sub_requirements=[
+                RawRequirementItem(
+                    id="b",
+                    content_nodes=self.extractor.extract_nodes(
+                        "(b) Compare requirements (1) and (2) above."
+                    ),
+                ),
+                RawRequirementItem(
+                    id="1",
+                    content_nodes=self.extractor.extract_nodes("1. First topic."),
+                ),
+                RawRequirementItem(
+                    id="2",
+                    content_nodes=self.extractor.extract_nodes("2. Second topic."),
+                ),
+            ],
+        )
+
+        requirements = self.processor.process([parent])
+
+        self.assertEqual(
+            [child.requirement_path for child in requirements[0].sub_requirements],
+            ["1.b", "1.1", "1.2"],
+        )
+        self.assertEqual(requirements[0].sub_requirements[0].sub_requirements, [])
 
     def test_option_prefixed_action_requirements_stay_answerable(self) -> None:
         html = """

--- a/tests/test_validate_merit_badges_archive.py
+++ b/tests/test_validate_merit_badges_archive.py
@@ -28,6 +28,7 @@ def requirement(label: str) -> dict:
         "node_kind": "action_requirement",
         "is_container": False,
         "requires_response": True,
+        "scoped_clauses": [],
         "content": [{"type": "text", "value": f"Requirement {label}."}],
         "resources": [],
         "sub_requirements": [],
@@ -117,6 +118,50 @@ class ValidateMeritBadgesArchiveTest(unittest.TestCase):
 
         self.assertFalse(
             any("likely governs numbered siblings" in warning for warning in warnings)
+        )
+
+    def test_warns_when_action_clause_scope_is_ambiguous(self) -> None:
+        ambiguous = requirement("1")
+        ambiguous["text"] = "Explain the rule and do ONE of the following:"
+        ambiguous["content"] = [{"type": "text", "value": ambiguous["text"]}]
+        ambiguous["scoped_clauses"] = [
+            {"text": ambiguous["text"], "scope": "ambiguous"}
+        ]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "ambiguous-scope-merit-badge.json"
+            file_path.write_text(
+                json.dumps(badge([ambiguous, requirement("2")])),
+                encoding="utf-8",
+            )
+
+            errors, warnings = validate_merit_badges_archive.validate_badge_content(
+                file_path
+            )
+
+        self.assertFalse(errors)
+        self.assertTrue(
+            any("ambiguous action scope" in warning for warning in warnings)
+        )
+
+    def test_rejects_suppressed_requirement_scoped_action(self) -> None:
+        suppressed = requirement("1")
+        suppressed["requires_response"] = False
+        suppressed["scoped_clauses"] = [
+            {"text": suppressed["text"], "scope": "requirement"}
+        ]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "suppressed-action-merit-badge.json"
+            file_path.write_text(
+                json.dumps(badge([suppressed, requirement("2")])),
+                encoding="utf-8",
+            )
+
+            errors, _warnings = validate_merit_badges_archive.validate_badge_content(
+                file_path
+            )
+
+        self.assertTrue(
+            any("suppresses a requirement-scoped action" in error for error in errors)
         )
 
 

--- a/tests/test_validate_merit_badges_archive.py
+++ b/tests/test_validate_merit_badges_archive.py
@@ -34,6 +34,23 @@ def requirement(label: str) -> dict:
     }
 
 
+def badge(requirements: list[dict]) -> dict:
+    return {
+        "name": "Hierarchy Test",
+        "overview": "A valid overview long enough for validation.",
+        "is_eagle_required": False,
+        "is_lab": False,
+        "url": "https://www.scouting.org/merit-badges/hierarchy-test/",
+        "pdf_url": "",
+        "workbook_pdf_url": "",
+        "workbook_docx_url": "",
+        "shop_url": "",
+        "image_url": "",
+        "image_filename": "",
+        "requirements": requirements,
+    }
+
+
 class ValidateMeritBadgesArchiveTest(unittest.TestCase):
     def test_empty_required_name_is_error(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -63,6 +80,44 @@ class ValidateMeritBadgesArchiveTest(unittest.TestCase):
             )
 
         self.assertIn("Empty required field: name", errors)
+
+    def test_warns_about_likely_governed_numbered_siblings(self) -> None:
+        governing = requirement("a")
+        governing["text"] = "Choose two situations from the list below."
+        governing["content"] = [{"type": "text", "value": governing["text"]}]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "hierarchy-test-merit-badge.json"
+            file_path.write_text(
+                json.dumps(badge([governing, requirement("1"), requirement("2")])),
+                encoding="utf-8",
+            )
+
+            _errors, warnings = validate_merit_badges_archive.validate_badge_content(
+                file_path
+            )
+
+        self.assertTrue(
+            any("likely governs numbered siblings" in warning for warning in warnings)
+        )
+
+    def test_does_not_warn_for_parenthetical_numeric_references(self) -> None:
+        nongoverning = requirement("b")
+        nongoverning["text"] = "Compare requirements (1) and (2) above."
+        nongoverning["content"] = [{"type": "text", "value": nongoverning["text"]}]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "hierarchy-test-merit-badge.json"
+            file_path.write_text(
+                json.dumps(badge([nongoverning, requirement("1"), requirement("2")])),
+                encoding="utf-8",
+            )
+
+            _errors, warnings = validate_merit_badges_archive.validate_badge_content(
+                file_path
+            )
+
+        self.assertFalse(
+            any("likely governs numbered siblings" in warning for warning in warnings)
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- reparent contiguous numbered topic and option lists under the alphabetic action or named option that governs them
- preserve source IDs, content, resources, action/container semantics, and recompute paths from the repaired tree
- warn when archive validation detects likely governed numeric siblings that remain flattened
- document the semantic JSON hierarchy behavior and add focused regression coverage

## Validation
- make check
- uv run python -m unittest discover -s tests -v (26 tests)
- corpus replay: 23 groups / 136 leaves repaired across 18 badges, with zero governed groups remaining
- verified payload preservation, unique paths, consistent container flags, and unchanged node_kind/requires_response metadata
- replayed live browser-captured markup for Emergency Preparedness, Disabilities Awareness, and Camping through the production extractor and semantic processor